### PR TITLE
Fractional Float output

### DIFF
--- a/lib/unicode_math/fractional_output.rb
+++ b/lib/unicode_math/fractional_output.rb
@@ -1,24 +1,35 @@
 # encoding: utf-8
 
-class Float
-  alias_method :old_to_s, :to_s
-  def to_s
-    frac =
-      case self % 1
-      when ⅛ then '⅛'
-      when ⅙ then '⅙'
-      when ⅕ then '⅕'
-      when ¼ then '¼'
-      when ⅓ then '⅓'
-      when ⅜ then '⅜'
-      when ½ then '½'
-      when ⅝ then '⅝'
-      when ⅔ then '⅔'
-      when ⅚ then '⅚'
-      when ¾ then '¾'
-      when ⅞ then '⅞'
-      else return old_to_s
+module UnicodeMath
+  module FractionalOutput
+    def self.included(base)
+      base.class_eval do
+        alias_method :old_to_s, :to_s
+        def to_s
+          frac =
+            case self % 1
+            when ⅛ then '⅛'
+            when ⅙ then '⅙'
+            when ⅕ then '⅕'
+            when ¼ then '¼'
+            when ⅓ then '⅓'
+            when ⅜ then '⅜'
+            when ⅖ then '⅖'
+            when ½ then '½'
+            when ⅗ then '⅗'
+            when ⅝ then '⅝'
+            when ⅔ then '⅔'
+            when ⅘ then '⅘'
+            when ⅚ then '⅚'
+            when ¾ then '¾'
+            when ⅞ then '⅞'
+            else return old_to_s
+            end
+          "#{self >= 1 ? floor : ''}#{frac}"
+        end
       end
-    "#{self >= 1 ? floor : ''}#{frac}"
+    end
   end
 end
+
+Float.send(:include, UnicodeMath::FractionalOutput)

--- a/spec/unicode_math/fractional_output_spec.rb
+++ b/spec/unicode_math/fractional_output_spec.rb
@@ -1,0 +1,75 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe UnicodeMath::FractionalOutput do
+  it 'displays one half as ½' do
+    expect((1.0/2).to_s).to eq('½')
+  end
+
+  describe 'thirds' do
+    it 'displays one third as ⅓' do
+      expect((1.0/3).to_s).to eq('⅓')
+    end
+
+    it 'displays two thirds as ⅔' do
+      expect((2.0/3).to_s).to eq('⅔')
+    end
+  end
+
+  describe 'quarters' do
+    it 'displays one quarter as ¼' do
+      expect((1.0/4).to_s).to eq('¼')
+    end
+
+    it 'displays three quarters as ¾' do
+      expect((3.0/4).to_s).to eq('¾')
+    end
+  end
+
+  describe 'fifths' do
+    it 'displays one fifth as ⅕' do
+      expect((1.0/5).to_s).to eq('⅕')
+    end
+
+    it 'displays two fifths as ⅖' do
+      expect((2.0/5).to_s).to eq('⅖')
+    end
+
+    it 'displays three fifths as ⅗' do
+      expect((3.0/5).to_s).to eq('⅗')
+    end
+
+    it 'displays four fifths as ⅘' do
+      expect((4.0/5).to_s).to eq('⅘')
+    end
+  end
+
+  describe 'sixths' do
+    it 'displays one sixth as ⅙' do
+      expect((1.0/6).to_s).to eq('⅙')
+    end
+
+    it 'displays five sixths as ⅚' do
+      expect((5.0/6).to_s).to eq('⅚')
+    end
+  end
+
+  describe 'eighths' do
+    it 'displays one eighth as ⅛' do
+      expect((1.0/8).to_s).to eq('⅛')
+    end
+
+    it 'displays three eighths as ⅜' do
+      expect((3.0/8).to_s).to eq('⅜')
+    end
+
+    it 'displays five eighths as ⅝' do
+      expect((5.0/8).to_s).to eq('⅝')
+    end
+
+    it 'displays seven eighths as ⅞' do
+      expect((7.0/8).to_s).to eq('⅞')
+    end
+  end
+end


### PR DESCRIPTION
There's probably a cleaner way of doing this monkey patch, but the idea is now you can:

```
irb(main):002:0> ¾ * ½
=> ⅜
```
