### PR TITLE
Add set operators: ∩ (intersection) / ∪ (union)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ You can raise to the powers of 0–9 as well as arbitrary numbers:
 
     5.× 5
 
+### Array as set
+
+    [2, 3, 5, 7].∩ [3, 5, 7, 9]
+    [2, 3, 5, 7].∪ [3, 5, 7, 9]
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/unicode_math/set.rb
+++ b/lib/unicode_math/set.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+module UnicodeMath
+  module Set
+    def self.included(base)
+      base.class_eval do
+        define_method('∩') do |set|
+          self & set
+        end
+
+        define_method('∪') do |set|
+          self | set
+        end
+      end
+    end
+  end
+end
+
+Array.send(:include, UnicodeMath::Set)

--- a/spec/unicode_math/set_spec.rb
+++ b/spec/unicode_math/set_spec.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe UnicodeMath::Set do
+  before do
+    @primes   = [2, 3, 5, 7]
+    @odd_nums = [3, 5, 7, 9]
+  end
+
+  it 'defines the intersection operator: ∩' do
+    intersection = @primes.∩ @odd_nums
+    expect(intersection).to eq([3, 5, 7])
+  end
+
+  it 'defines the union operator: ∪' do
+    union = @primes.∪ @odd_nums
+    expect(union).to eq([2, 3, 5, 7, 9])
+  end
+end


### PR DESCRIPTION
Should we also extend Set? 

I am not sure why we don't simply do something like this:

``` ruby
class Array
  alias_method :∩ :&
  alias_method :∪ :|
end
```
