### PR TITLE
Geometry

### DIFF
--- a/lib/unicode_math/geometry.rb
+++ b/lib/unicode_math/geometry.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+
+module UnicodeMath
+  module Geometry
+    def self.included(base)
+      base.class_eval do
+      	def calculate_distance(points1,points2)
+      		Math.sqrt((points2[1]-points1[1])**2 + (points2[0]-points1[0])**2)
+      	end
+        
+        define_method('↔') do |array|
+        	calculate_distance(self,array)
+        end
+
+        define_method('≅') do |array|
+          #SSS congruency
+          	
+          dist1 = Array.new
+          dist2 = Array.new
+          if(self.size() == 1)
+          	dist1 = 1 #Points are always congruent
+          else self.size() >= 2
+          	s = self.size() - 2
+          	(0..s).each do |i|  		
+          		dist1.push(calculate_distance(self[i],self[i + 1]))
+          	end
+          		dist1.push(calculate_distance(self[s + 1],self[0]))
+          end
+
+          if(array.size() == 1)
+          	dist2 = 1 #Points are always congruent
+          else array.size() >= 2
+          	s = array.size() - 2
+          	(0..s).each do |i|  		
+          		dist2.push(calculate_distance(array[i],array[i + 1]))
+          	end
+          		dist2.push(calculate_distance(array[s + 1],array[0]))
+          end
+          
+          (dist1 == dist2)
+        end
+      end
+    end
+  end
+end
+
+Array.send(:include, UnicodeMath::Geometry)

--- a/spec/unicode_math/geometry_spec.rb
+++ b/spec/unicode_math/geometry_spec.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe UnicodeMath::Geometry do
+  before do
+  	@triangle_points_1 = [[0,3],[3,0],[0,0]]
+  	@triangle_points_2 = [[0,0],[0,5],[6,0]]
+  	@line1 = [[0,0],[0,5]]
+  	@line2 = [[2,0],[0,3]]
+  	@point1 = [0,0]
+  	@point2 = [0,3]
+  end
+  
+  it 'defines congruency in triangles' do
+    expect(@triangle_points_1.≅ @triangle_points_1).to eq(true)
+  end
+
+  it 'defines congruency in triangles' do
+    expect(@triangle_points_1.≅ @triangle_points_2).to eq(false)
+  end
+
+
+  it 'defines congruent lines' do
+    expect(@line1.≅ @line1).to eq(true)
+  end
+
+  it 'defines congruent lines' do
+    expect(@line1.≅ @line2).to eq(false)
+  end
+
+  it 'defines distance between two points' do
+    expect(@point1.↔ @point2).to eq(3.0)
+  end
+
+end


### PR DESCRIPTION
Now, distance between two points can be calculated using  **point1.↔ point2**
Congruency in triangles using SSS congruency : **triangle_points1.≅ triangle_points2**
More can be added like calculating angles between two lines.